### PR TITLE
fix: reusable dom visible problem

### DIFF
--- a/src/engine/virtual-element.ts
+++ b/src/engine/virtual-element.ts
@@ -59,6 +59,7 @@ export class VirtualElement<T> {
           break;
       }
       this.wrapperElement = reusable.wrapperElement;
+      this.wrapperElement.classList.remove('hidden');
       this.renderer = reusable.renderer;
       if (!this.wrapperElement.parentElement) {
         this.parent.container.appendChild(this.wrapperElement);
@@ -81,6 +82,7 @@ export class VirtualElement<T> {
           index: this.index,
         });
       }
+      wrapperElement?.classList.add('hidden');
       return {
         renderer: renderer,
         wrapperElement: wrapperElement,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -30,6 +30,10 @@
       position: absolute;
       display: flex;
       // border-bottom: 1px solid red;
+
+      &.hidden {
+        visibility: hidden;
+      }
     }
   }
 }


### PR DESCRIPTION
# Problems

- previous reusable doms appeared in scroll area

# Solutions

- add 'hidden' class to reusable but not currently necessary virtual dom
